### PR TITLE
product card design fixes (minor)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,3 +14,4 @@ export {default as Pagination} from './src/components/pagination';
 export {default as ProductCard} from './src/components/productCard';
 export {default as QuantityInput} from './src/components/quantity';
 export {default as Search} from './src/components/searchBar';
+export {default as VerticalTabs} from './src/components/verticalTab';

--- a/src/components/productCard.tsx
+++ b/src/components/productCard.tsx
@@ -70,7 +70,6 @@ type imageProp = {
 const ProductImage = styled('div')<imageProp>`
   width: 227px;
   height: 218px;
-  border: 2px solid blue;
   z-index: 2;
   img {
     width: 227px;


### PR DESCRIPTION
<img width="523" alt="Screenshot 2022-12-16 at 10 29 08 PM" src="https://user-images.githubusercontent.com/90173866/208150018-fa381f03-d6d8-4e36-92ee-b2bc46799072.png">
looks way cleaner without the blue border 
<img width="525" alt="Screenshot 2022-12-16 at 10 29 41 PM" src="https://user-images.githubusercontent.com/90173866/208150107-95242b1f-8111-4b2a-971f-872c6c0dd3f5.png">
this one is with the border